### PR TITLE
Prepare the Submission for Evaluation

### DIFF
--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -2,7 +2,7 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-label: Run the submission against the Organizers pipeline for Scoring
+label: Run the submission against the Organizers pipeline for dciodvfy
 
 requirements:
   - class: InlineJavascriptRequirement

--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -12,10 +12,10 @@ inputs:
     type: File
 
 outputs:
-  - id: scoring_results
+  - id: dciodvfy_results
     type: File
     outputBinding:
-      glob: scoringreport.csv
+      glob: dciodvfy_report.csv
 
   - id: results
     type: File
@@ -31,7 +31,7 @@ outputs:
 
 baseCommand: python
 arguments:
-  - valueFrom: MIDI_validation_script/run_validation.py
+  - valueFrom: MIDI_validation_script/run_dciodvfy.py
   - prefix: --config_file
     valueFrom: $(inputs.config_file)
 

--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -18,9 +18,9 @@ outputs:
       glob: dciodvfy_report.csv
 
   # - id: results
-    # type: File
-    # outputBinding:
-    #   glob: results.json
+  #   type: File
+  #   outputBinding:
+  #     glob: results.json
 
   # - id: status
   #   type: string

--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -17,17 +17,17 @@ outputs:
     outputBinding:
       glob: dciodvfy_report.csv
 
-  - id: results
-    type: File
-    outputBinding:
-      glob: results.json
+  # - id: results
+    # type: File
+    # outputBinding:
+    #   glob: results.json
 
-  - id: status
-    type: string
-    outputBinding:
-      glob: results.json
-      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
-      loadContents: true
+  # - id: status
+  #   type: string
+  #   outputBinding:
+  #     glob: results.json
+  #     outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+  #     loadContents: true
 
 baseCommand: python
 arguments:

--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -1,0 +1,40 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: Run the submission against the Organizers pipeline for Discrepancies
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: config_file
+    type: File
+
+outputs:
+  - id: discrepancy_results
+    type: File
+    outputBinding:
+      glob: discrepancy_report.csv
+
+  - id: results
+    type: File
+    outputBinding:
+      glob: results.json
+
+  - id: status
+    type: string
+    outputBinding:
+      glob: results.json
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+      loadContents: true
+
+baseCommand: python
+arguments:
+  - valueFrom: MIDI_validation_script/run_reports.py
+  - prefix: --config_file
+    valueFrom: $(inputs.config_file)
+
+hints:
+  DockerRequirement:
+    dockerPull: docker.synapse.org/syn53065762/validate_score:v4

--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -17,17 +17,17 @@ outputs:
     outputBinding:
       glob: discrepancy_report.csv
 
-  - id: results
-    type: File
-    outputBinding:
-      glob: results.json
+  # - id: results
+  #   type: File
+  #   outputBinding:
+  #     glob: results.json
 
-  - id: status
-    type: string
-    outputBinding:
-      glob: results.json
-      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
-      loadContents: true
+  # - id: status
+  #   type: string
+  #   outputBinding:
+  #     glob: results.json
+  #     outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+  #     loadContents: true
 
 baseCommand: python
 arguments:

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -41,7 +41,7 @@ requirements:
       scoring = syn.store(scoring)
       results['scoring'] = scoring.id
       with open('results.json', 'w') as out:
-          out.write(json.dumps(results, out))
+          json.dump(results, out)
 
 inputs:
 - id: dciovdfy_results

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -18,6 +18,8 @@ requirements:
 
       parser = argparse.ArgumentParser()
       parser.add_argument("--dciovdfy_file", required=True)
+      parser.add_argument("--discrepancy_file", required=True)
+      parser.add_argument("--scoring_file", required=True)
       parser.add_argument("-c", "--synapse_config", required=True)
       parser.add_argument("--parent_id", required=True)
       args = parser.parse_args()
@@ -25,12 +27,27 @@ requirements:
       syn = synapseclient.Synapse(configPath=args.synapse_config)
       syn.login()
 
-      results = {}
+      dciovdfy_results = {}
+      discrepancy_results = {}
+      scoring_results = {}
+
       dciovdfy = synapseclient.File(args.dciovdfy_file, parent=args.parent_id)
       dciovdfy = syn.store(dciovdfy)
-      results['dciovdfy'] = dciovdfy.id
+      dciovdfy_results['dciovdfy'] = dciovdfy.id
       with open('results.json', 'w') as out:
-        out.write(json.dumps(results))
+          out.write(json.dumps(dciovdfy_results))
+
+      discrepancy = synapseclient.File(args.discrepancy_file, parent=args.parent_id)
+      discrepancy = syn.store(discrepancy)
+      discrepancy_results['discrepancy'] = discrepancy.id
+      with open('results.json', 'w') as out:
+          out.write(json.dumps(discrepancy_results))
+
+      scoring = synapseclient.File(args.scoring_file, parent=args.parent_id)
+      scoring = syn.store(scoring)
+      scoring_results['scoring'] = scoring.id
+      with open('results.json', 'w') as out:
+          out.write(json.dumps(scoring_results))
 
 inputs:
 - id: dciovdfy_results
@@ -59,7 +76,7 @@ arguments:
   valueFrom: $(inputs.dciovdfy_results)
 - prefix: -c
   valueFrom: $(inputs.synapse_config.path)
-- prefix: --parent
+- prefix: --parent_id
   valueFrom: $(inputs.parent_id)
 
 hints:

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -27,30 +27,28 @@ requirements:
       syn = synapseclient.Synapse(configPath=args.synapse_config)
       syn.login()
 
-      dciovdfy_results = {}
-      discrepancy_results = {}
-      scoring_results = {}
+      results = {}
 
       dciovdfy = synapseclient.File(args.dciovdfy_file, parent=args.parent_id)
       dciovdfy = syn.store(dciovdfy)
-      dciovdfy_results['dciovdfy'] = dciovdfy.id
-      with open('results.json', 'w') as out:
-          out.write(json.dumps(dciovdfy_results))
+      results['dciovdfy'] = dciovdfy.id
 
       discrepancy = synapseclient.File(args.discrepancy_file, parent=args.parent_id)
       discrepancy = syn.store(discrepancy)
-      discrepancy_results['discrepancy'] = discrepancy.id
-      with open('results.json', 'w') as out:
-          out.write(json.dumps(discrepancy_results))
+      results['discrepancy'] = discrepancy.id
 
       scoring = synapseclient.File(args.scoring_file, parent=args.parent_id)
       scoring = syn.store(scoring)
-      scoring_results['scoring'] = scoring.id
+      results['scoring'] = scoring.id
       with open('results.json', 'w') as out:
-          out.write(json.dumps(scoring_results))
+          out.write(json.dumps(results, out))
 
 inputs:
 - id: dciovdfy_results
+  type: File
+- id: discrepancy_results
+  type: File
+- id: scoring_results
   type: File
 - id: parent_id
   type: string
@@ -62,18 +60,38 @@ outputs:
   type: File
   outputBinding:
     glob: results.json
-- id: dciovdfy_synid
-  type: string
-  outputBinding:
-    glob: results.json
-    outputEval: $(JSON.parse(self[0].contents)['dciovdfy'])
-    loadContents: true
+outputs:
+  - id: dciovdfy_synid
+    type: string
+    outputBinding:
+      glob: results.json
+      outputEval: $(JSON.parse(self[0].contents)['dciovdfy'])
+      loadContents: true
+
+  - id: discrepancy_synid
+    type: string
+    outputBinding:
+      glob: results.json
+      outputEval: $(JSON.parse(self[0].contents)['discrepancy'])
+      loadContents: true
+
+  - id: scoring_synid
+    type: string
+    outputBinding:
+      glob: results.json
+      outputEval: $(JSON.parse(self[0].contents)['scoring'])
+      loadContents: true
+
 
 baseCommand: python3
 arguments:
 - valueFrom: upload_results_to_synapse.py
 - prefix: --dciovdfy_file
   valueFrom: $(inputs.dciovdfy_results)
+- prefix: --discrepancy_file
+  valueFrom: $(inputs.discrepancy_results)
+- prefix: --scoring_file
+  valueFrom: $(inputs.scoring_results)
 - prefix: -c
   valueFrom: $(inputs.synapse_config.path)
 - prefix: --parent_id

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -60,7 +60,6 @@ outputs:
   type: File
   outputBinding:
     glob: results.json
-outputs:
   - id: dciovdfy_synid
     type: string
     outputBinding:

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -60,26 +60,26 @@ outputs:
   type: File
   outputBinding:
     glob: results.json
-  - id: dciovdfy_synid
-    type: string
-    outputBinding:
-      glob: results.json
-      outputEval: $(JSON.parse(self[0].contents)['dciovdfy'])
-      loadContents: true
+- id: dciovdfy_synid
+  type: string
+  outputBinding:
+    glob: results.json
+    outputEval: $(JSON.parse(self[0].contents)['dciovdfy'])
+    loadContents: true
 
-  - id: discrepancy_synid
-    type: string
-    outputBinding:
-      glob: results.json
-      outputEval: $(JSON.parse(self[0].contents)['discrepancy'])
-      loadContents: true
+- id: discrepancy_synid
+  type: string
+  outputBinding:
+    glob: results.json
+    outputEval: $(JSON.parse(self[0].contents)['discrepancy'])
+    loadContents: true
 
-  - id: scoring_synid
-    type: string
-    outputBinding:
-      glob: results.json
-      outputEval: $(JSON.parse(self[0].contents)['scoring'])
-      loadContents: true
+- id: scoring_synid
+  type: string
+  outputBinding:
+    glob: results.json
+    outputEval: $(JSON.parse(self[0].contents)['scoring'])
+    loadContents: true
 
 
 baseCommand: python3

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -1,0 +1,67 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+label: Get result files then upload to Synapse
+
+requirements:
+- class: InlineJavascriptRequirement
+- class: InitialWorkDirRequirement
+  listing:
+  - entryname: upload_results_to_synapse.py
+    entry: |
+      #!/usr/bin/env python
+      import synapseclient
+      import argparse
+      import json
+      import os
+      import tarfile
+
+      parser = argparse.ArgumentParser()
+      parser.add_argument("--dciovdfy_file", required=True)
+      parser.add_argument("-c", "--synapse_config", required=True)
+      parser.add_argument("--parent_id", required=True)
+      args = parser.parse_args()
+
+      syn = synapseclient.Synapse(configPath=args.synapse_config)
+      syn.login()
+
+      results = {}
+      dciovdfy = synapseclient.File(args.dciovdfy_file, parent=args.parent_id)
+      dciovdfy = syn.store(dciovdfy)
+      results['dciovdfy'] = dciovdfy.id
+      with open('results.json', 'w') as out:
+        out.write(json.dumps(results))
+
+inputs:
+- id: dciovdfy_results
+  type: File
+- id: parent_id
+  type: string
+- id: synapse_config
+  type: File
+
+outputs:
+- id: results
+  type: File
+  outputBinding:
+    glob: results.json
+- id: dciovdfy_synid
+  type: string
+  outputBinding:
+    glob: results.json
+    outputEval: $(JSON.parse(self[0].contents)['dciovdfy'])
+    loadContents: true
+
+baseCommand: python3
+arguments:
+- valueFrom: upload_results_to_synapse.py
+- prefix: --dciovdfy_file
+  valueFrom: $(inputs.dciovdfy_results)
+- prefix: -c
+  valueFrom: $(inputs.synapse_config.path)
+- prefix: --parent
+  valueFrom: $(inputs.parent_id)
+
+hints:
+  DockerRequirement:
+    dockerPull: sagebionetworks/synapsepythonclient:v2.7.2

--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -1,0 +1,21 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: compressed_file
+    type: File
+
+outputs:
+  - id: config_file
+    type: File
+
+baseCommand: python
+arguments:
+  - valueFrom: unzip_submission.py
+  - prefix: --compressed_file
+    valueFrom: $(inputs.compressed_file)

--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -13,6 +13,8 @@ inputs:
 outputs:
   - id: config_file
     type: File
+  - id: writeup_file
+    type: File
 
 baseCommand: python
 arguments:

--- a/steps/unzip_submission.py
+++ b/steps/unzip_submission.py
@@ -20,9 +20,16 @@ import json
 import zipfile
 
 def inspect_zip(zip_path):
-    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        zip_ref.extractall("submission")
-        file_paths = [os.path.join("submission", name) for name in zip_ref.namelist()]
+    if zipfile.is_zipfile(zip_path):
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall("submission")
+            file_paths = [os.path.join("submission", name) for name in zip_ref.namelist()]
+    elif tarfile.is_tarfile(zip_path):
+        with tarfile.open(zip_path, 'r') as tar_ref:
+            tar_ref.extractall("submission")
+            file_paths = [os.path.join("submission", name) for name in tar_ref.getnames()]
+    else:
+        raise ValueError(f"The file {zip_path} is not a valid zip or tar file.")
     return file_paths
 
 def create_config(file_paths):
@@ -78,3 +85,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/steps/unzip_submission.py
+++ b/steps/unzip_submission.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Preparing the submission for Evaluation. MIDI-B 2024
+"""
+Preparing the submission for Evaluation. MIDI-B 2024
 
 Submissions will be made as a compressed collection of 
-files and subfolders. The folllowing should be included
+files and subfolders. The following should be included
 in the submission but only the last 3 will be used in 
 the config.json:
 1. Write-up
@@ -41,20 +42,22 @@ def create_config(file_paths):
     }
 
     images = []
+    writeup = None
 
     for file_path in file_paths:
-        if file_path.contains("uid_mapping"):
+        if "uid_mapping" in file_path:
             config["uid_mapping_file"] = file_path
-        elif file_path.contains("patid_mapping"):
+        elif "patid_mapping" in file_path:
             config["patid_mapping_file"] = file_path
+        elif "writeup" in file_path:
+            writeup = file_path
         else:
             images.append(file_path)
 
     if images:
         config["input_data_path"] = os.path.dirname(images[0])
-
-    with open("config.json", "w") as config_file:
-        json.dump(config, config_file, indent=4)
+    
+    return config, writeup
 
 def main():
     """Main function."""
@@ -67,9 +70,10 @@ def main():
 
     # Create the config.json file using the 
     # filepaths of the submission components
-    create_config(file_paths)
+    config, writeup = create_config(file_paths)
 
-    # Return the config.json content
+    # Print the write-up file path and the config.json content
+    print("Write-up file path:", writeup)
     print(json.dumps(config, indent=4))
 
 if __name__ == "__main__":

--- a/steps/unzip_submission.py
+++ b/steps/unzip_submission.py
@@ -45,9 +45,9 @@ def create_config(file_paths):
     writeup = None
 
     for file_path in file_paths:
-        if "uid_mapping" in file_path:
+        if "mappings" in file_path and "uid_mapping" in file_path:
             config["uid_mapping_file"] = file_path
-        elif "patid_mapping" in file_path:
+        elif "mappings" in file_path and "patid_mapping" in file_path:
             config["patid_mapping_file"] = file_path
         elif "writeup" in file_path:
             writeup = file_path

--- a/steps/unzip_submission.py
+++ b/steps/unzip_submission.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Preparing the submission for Evaluation. MIDI-B 2024
+
+Submissions will be made as a compressed collection of 
+files and subfolders. The folllowing should be included
+in the submission but only the last 3 will be used in 
+the config.json:
+1. Write-up
+2. uid_mapping_file.csv
+3. patid_mapping.csv
+4. Folder with the de-identified images. 
+This script will decompress the submission and create a config file
+to be used when evaluating the submission using a Docker image.
+"""
+
+import os
+import argparse
+import json
+import zipfile
+
+def inspect_zip(zip_path):
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall("submission")
+        file_paths = [os.path.join("submission", name) for name in zip_ref.namelist()]
+    return file_paths
+
+def create_config(file_paths):
+    """Create config.json from file paths."""
+    config = {
+        "run_name": "MIDI_1_1_Testing",
+        "input_data_path": None,
+        "output_data_path": "~/results",
+        "answer_db_file": "~/MIDI_validation_script/midi_1_1_answer_data_1.db",
+        "uid_mapping_file": None,
+        "patid_mapping_file": None,
+        "multiprocessing": "True",
+        "multiprocessing_cpus": "5",
+        "log_path": "~/logs",
+        "log_level": "info",
+        "report_series": "True"
+    }
+
+    images = []
+
+    for file_path in file_paths:
+        if file_path.contains("uid_mapping"):
+            config["uid_mapping_file"] = file_path
+        elif file_path.contains("patid_mapping"):
+            config["patid_mapping_file"] = file_path
+        else:
+            images.append(file_path)
+
+    if images:
+        config["input_data_path"] = os.path.dirname(images[0])
+
+    with open("config.json", "w") as config_file:
+        json.dump(config, config_file, indent=4)
+
+def main():
+    """Main function."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--compressed_file",
+                        type=str, required=True)
+    args = parser.parse_args()
+
+    file_paths = inspect_zip(args.compressed_file)
+
+    # Create the config.json file using the 
+    # filepaths of the submission components
+    create_config(file_paths)
+
+    # Return the config.json content
+    print(json.dumps(config, indent=4))
+
+if __name__ == "__main__":
+    main()

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -79,18 +79,6 @@ steps:
       - id: entity_id
       - id: entity_type
       - id: results
-      
-  # Commented out as this process is still pending 
-  # and this was a placeholder
-  # create_config_file:
-  #   run: /bin/bash
-  #   label: "Create config.json"
-  #   in:
-  #     - id: submitter_folder_id
-  #       source: "#submitter_folder_id"
-  #     - id: submissionId
-  #       source: "#submissionId"
-  #   out: [config_file]
 
   unzip_generate_config:
     run: steps/unzip_submission.cwl
@@ -152,7 +140,7 @@ steps:
         source: "#notify_filepath_status/finished"
     out: [finished]
     
-    create_scoring_report:
+  create_scoring_report:
     run: steps/score.cwl
     in:
       - id: config_json
@@ -162,6 +150,7 @@ steps:
       - id: results
       - id: status
     
+
   create_discrepancy_report:
     run: steps/discrepancy.cwl
     in:
@@ -171,6 +160,7 @@ steps:
       - id: discrepancy_results
       - id: results
       - id: status
+
 
   create_dciovdfy_report:
     run: steps/dciodvfy.cwl
@@ -182,6 +172,24 @@ steps:
       - id: results
       - id: status
 
+  upload_to_synapse:
+    run: steps/synapse_upload.cwl
+    in:
+      - id: synapse_config   # this input is needed so that uploading to Synapse is possible
+        source: "#synapseConfig"
+      - id: parent_id  # this input is needed so that Synapse knows where to upload file
+        source: "#adminUploadSynId"
+      - id: dciovdfy_results
+        source: "#create_dciovdfy_report/dciovdfy_results"
+      - id: discrepancy_results
+        source: "#create_dciovdfy_report/discrepancy_results"
+      - id: scoring_results
+        source: "#create_scoring_report/scoring_results"
+    out:
+      - id: dciovdfy_synid
+      - id: discrepancy_synid
+      - id: dciovdfy_synid
+      
   # download_goldstandard:
   #   run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl
   #   in:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -92,6 +92,15 @@ steps:
   #       source: "#submissionId"
   #   out: [config_file]
 
+  validate:
+    run: steps/unzip_submission.cwl
+    in:
+      - id: compressed_file
+        source: "#download_compressed_file/filepath"
+    out:
+      - id: config_json
+
+
   download_goldstandard:
     run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl
     in:
@@ -101,7 +110,7 @@ steps:
       - id: synapse_config
         source: "#synapseConfig"
     out:
-      - id: filepath
+      - id: filepath_gold
       
   validate:
     run: writeup/validate.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -100,6 +100,43 @@ steps:
     out:
       - id: config_json
       - id: writeup_file
+      - id: status
+      - id: invalid_reasons
+
+  notify_docker_status:
+    doc: Notify participant if submission is not a Docker image.
+    run: |-
+      https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/validate_email.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: status
+        source: "#unzip_generate_config/status"
+      - id: invalid_reasons
+        source: "#unzip_generate_config/invalid_reasons"
+      - id: errors_only
+        default: true
+    out: [finished]
+
+  add_status_annots:
+    doc: >
+      Add 'submission_status' and 'submission_errors' annotations to the
+      submission
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#unzip_generate_config/results"
+      - id: to_public
+        default: true
+      - id: force
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: [finished]
 
   create_scoring_report:
     run: steps/score.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -103,7 +103,7 @@ steps:
       - id: status
       - id: invalid_reasons
 
-  notify_docker_status:
+  notify_filepath_status:
     doc: Notify participant if submission is not a Docker image.
     run: |-
       https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/validate_email.cwl
@@ -138,7 +138,21 @@ steps:
         source: "#synapseConfig"
     out: [finished]
 
-  create_scoring_report:
+  check_filepath_status:
+    doc: >
+      Check the validation status of the submission; if 'INVALID', throw an
+      exception to stop the workflow
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/check_status.cwl
+    in:
+      - id: status
+        source: "#unzip_generate_config/status"
+      - id: previous_annotation_finished
+        source: "#add_status_annots/finished"
+      - id: previous_email_finished
+        source: "#notify_filepath_status/finished"
+    out: [finished]
+    
+    create_scoring_report:
     run: steps/score.cwl
     in:
       - id: config_json

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -168,7 +168,6 @@ steps:
     out:
       - id: dciovdfy_results
       - id: results
-      - id: status
 
   upload_to_synapse:
     run: steps/synapse_upload.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -92,13 +92,14 @@ steps:
   #       source: "#submissionId"
   #   out: [config_file]
 
-  validate:
+  unzip_generate_config:
     run: steps/unzip_submission.cwl
     in:
       - id: compressed_file
         source: "#download_compressed_file/filepath"
     out:
       - id: config_json
+      - id: writeup_file
 
 
   download_goldstandard:
@@ -115,6 +116,8 @@ steps:
   validate:
     run: writeup/validate.cwl
     in:
+      - id: writeup_file
+        source: "#unzip_generate_config/writeup_file"
       - id: synapse_config
         source: "#synapseConfig"
       - id: submissionid

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -158,7 +158,6 @@ steps:
         source: "#unzip_generate_config/config_json"
     out:
       - id: discrepancy_results
-      - id: status
 
 
   create_dciovdfy_report:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -158,7 +158,6 @@ steps:
         source: "#unzip_generate_config/config_json"
     out:
       - id: discrepancy_results
-      - id: results
       - id: status
 
 

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -197,6 +197,25 @@ steps:
   #   out:
   #     - id: filepath_gold
       
+  annotate_validation_with_output:
+    run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
+    in:
+      - id: dciovdfy_synid
+        source: "#upload_to_synapse/dciovdfy_synid"
+      - id: discrepancy_synid
+        source: "#upload_to_synapse/discrepancy_synid"
+      - id: scoring_synid
+        source: "#upload_to_synapse/scoring_synid"
+      - id: annotation_values
+        source: "#validate/results"
+      - id: to_public
+        default: true
+      - id: force
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: [finished]
+  
   validate:
     run: writeup/validate.cwl
     in:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -96,7 +96,7 @@ steps:
     run: steps/unzip_submission.cwl
     in:
       - id: compressed_file
-        source: "#download_compressed_file/filepath"
+        source: "#download_submission/filepath"
     out:
       - id: config_json
       - id: writeup_file

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -200,12 +200,6 @@ steps:
   annotate_validation_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
     in:
-      - id: dciovdfy_synid
-        source: "#upload_to_synapse/dciovdfy_synid"
-      - id: discrepancy_synid
-        source: "#upload_to_synapse/discrepancy_synid"
-      - id: scoring_synid
-        source: "#upload_to_synapse/scoring_synid"
       - id: annotation_values
         source: "#validate/results"
       - id: to_public

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -102,16 +102,16 @@ steps:
       - id: writeup_file
 
 
-  download_goldstandard:
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl
-    in:
-      # TODO: replace `valueFrom` with the Synapse ID to the challenge goldstandard
-      - id: synapseid
-        valueFrom: "syn58613732"
-      - id: synapse_config
-        source: "#synapseConfig"
-    out:
-      - id: filepath_gold
+  # download_goldstandard:
+  #   run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl
+  #   in:
+  #     # TODO: replace `valueFrom` with the Synapse ID to the challenge goldstandard
+  #     - id: synapseid
+  #       valueFrom: "syn58613732"
+  #     - id: synapse_config
+  #       source: "#synapseConfig"
+  #   out:
+  #     - id: filepath_gold
       
   validate:
     run: writeup/validate.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -196,7 +196,7 @@ steps:
   #       source: "#synapseConfig"
   #   out:
   #     - id: filepath_gold
-      
+  
   annotate_validation_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
     in:
@@ -215,7 +215,6 @@ steps:
       - id: synapse_config
         source: "#synapseConfig"
     out: [finished]
-  
   validate:
     run: writeup/validate.cwl
     in:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -197,11 +197,11 @@ steps:
   #   out:
   #     - id: filepath_gold
   
-  annotate_validation_with_output:
+  annotate_full_evaluation_with_output:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
     in:
       - id: annotation_values
-        source: "#validate/results"
+        source: "#upload_to_synapse/results"
       - id: to_public
         default: true
       - id: force
@@ -209,6 +209,7 @@ steps:
       - id: synapse_config
         source: "#synapseConfig"
     out: [finished]
+  
   validate:
     run: writeup/validate.cwl
     in:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -178,7 +178,7 @@ steps:
       - id: dciovdfy_results
         source: "#create_dciovdfy_report/dciovdfy_results"
       - id: discrepancy_results
-        source: "#create_dciovdfy_report/discrepancy_results"
+        source: "#create_discrepancy_report/discrepancy_results"
       - id: scoring_results
         source: "#create_scoring_report/scoring_results"
     out:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -185,6 +185,7 @@ steps:
       - id: dciovdfy_synid
       - id: discrepancy_synid
       - id: scoring_synid
+      - id: results
       
   # download_goldstandard:
   #   run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -188,7 +188,7 @@ steps:
     out:
       - id: dciovdfy_synid
       - id: discrepancy_synid
-      - id: dciovdfy_synid
+      - id: scoring_synid
       
   # download_goldstandard:
   #   run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -101,6 +101,35 @@ steps:
       - id: config_json
       - id: writeup_file
 
+  create_scoring_report:
+    run: steps/score.cwl
+    in:
+      - id: config_json
+        source: "#unzip_generate_config/config_json"
+    out:
+      - id: scoring_results
+      - id: results
+      - id: status
+    
+  create_discrepancy_report:
+    run: steps/discrepancy.cwl
+    in:
+      - id: config_json
+        source: "#unzip_generate_config/config_json"
+    out:
+      - id: discrepancy_results
+      - id: results
+      - id: status
+
+  create_dciovdfy_report:
+    run: steps/dciodvfy.cwl
+    in:
+      - id: config_json
+        source: "#unzip_generate_config/config_json"
+    out:
+      - id: dciovdfy_results
+      - id: results
+      - id: status
 
   # download_goldstandard:
   #   run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/cwl-tool-synapseclient/v1.4/cwl/synapse-get-tool.cwl

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -167,7 +167,6 @@ steps:
         source: "#unzip_generate_config/config_json"
     out:
       - id: dciovdfy_results
-      - id: results
 
   upload_to_synapse:
     run: steps/synapse_upload.cwl


### PR DESCRIPTION
This pull request addresses the need to prepare a config file for the submission after the compressed submission has been opened to allow the use of all files.

The steps are:
1. Unzip the compressed submission
2. Generate a config file using the paths to the de-identified images, uid and patid mapping CSV files
3. Run the steps in the following order:
![image](https://github.com/Sage-Bionetworks-Challenges/MIDI-B-De-identification/assets/122999770/a542ab23-5311-4e2b-b11b-e482fcdd7593)
**Please confirm whether I need to add the status check steps in between these to prevent them from running simultaneously**
4. Then validate the writeup (This may need to be changed as it currently checks to see if the writeup is a project which it won't be once the compressed submission is unzipped)