### PR TITLE
Fix Workflow Steps

### DIFF
--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -15,6 +15,16 @@ outputs:
     type: File
   - id: writeup_file
     type: File
+  - id: results
+    type: File
+    outputBinding:
+      glob: results.json
+  - id: status
+    type: string
+    outputBinding:
+      glob: results.json
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+      loadContents: true
 
 baseCommand: python
 arguments:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -90,6 +90,7 @@ steps:
       - id: writeup_file
       - id: status
       - id: invalid_reasons
+      - id: results
 
   notify_filepath_status:
     doc: Notify participant if submission is not a Docker image.
@@ -161,12 +162,12 @@ steps:
 
 
   create_dciovdfy_report:
-    run: steps/dciodvfy.cwl
+    run: steps/dicovdfy.cwl
     in:
       - id: config_json
         source: "#unzip_generate_config/config_json"
     out:
-      - id: dciovdfy_results
+      - id: dciodvfy_results
 
   upload_to_synapse:
     run: steps/synapse_upload.cwl
@@ -176,7 +177,7 @@ steps:
       - id: parent_id  # this input is needed so that Synapse knows where to upload file
         source: "#adminUploadSynId"
       - id: dciovdfy_results
-        source: "#create_dciovdfy_report/dciovdfy_results"
+        source: "#create_dciovdfy_report/dciodvfy_results"
       - id: discrepancy_results
         source: "#create_discrepancy_report/discrepancy_results"
       - id: scoring_results


### PR DESCRIPTION
The cwl validation check revealed that there was an issue with the output of create_dciovdfy_report.

The following changes were made:

1. Correct misspelled dciovdfy in several lines
2. Add results to the unzip_submission.cwl since the workflow.cwl was expecting the results.