### PR TITLE
Correct the Unzip Submission Workflow

### DIFF
--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -38,7 +38,7 @@ outputs:
 
 baseCommand: python
 arguments:
-  - valueFrom: unzip_submission.py
+  - valueFrom: steps/unzip_submission.py
   - prefix: --compressed_file
     valueFrom: $(inputs.compressed_file)
 

--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -41,3 +41,7 @@ arguments:
   - valueFrom: unzip_submission.py
   - prefix: --compressed_file
     valueFrom: $(inputs.compressed_file)
+
+hints:
+  DockerRequirement:
+    dockerPull: python:3.9.1-slim-buster


### PR DESCRIPTION
This PR has add the Python docker image and full path for the python file that must be executed to unzip the submission.