### PR TITLE
Update the CWL Language

### DIFF
--- a/workflow.cwl
+++ b/workflow.cwl
@@ -58,7 +58,7 @@ steps:
         source: "#submitterUploadSynId"
       # TODO: replace `valueFrom` with the admin user ID or admin team ID
       - id: principalid
-        valueFrom: "#organizers" 
+        source: "#organizers" 
       - id: permissions
         valueFrom: "download"
       - id: synapse_config


### PR DESCRIPTION
The #organizers variable needed to use source rather than valuefrom in line 61. That has been corrected.