### PR TITLE
Update unzip submissions workflow

### DIFF
--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -36,12 +36,8 @@ outputs:
       outputEval: $(JSON.parse(self[0].contents)['submission_errors'])
       loadContents: true
 
-baseCommand: python
+baseCommand: python3
 arguments:
   - valueFrom: steps/unzip_submission.py
   - prefix: --compressed_file
     valueFrom: $(inputs.compressed_file)
-
-hints:
-  DockerRequirement:
-    dockerPull: python:3.9.1-slim-buster


### PR DESCRIPTION
Corrected the workflow by removing the Hints: docker image of python and adding python3 to the basecommand rather than python.