### PR TITLE
Include Submission Unzipping in Docker Image

### DIFF
--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -37,4 +37,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn53065762/validate_score:v4
+    dockerPull: docker.synapse.org/syn53065762/validate_score:v5

--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -37,4 +37,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn53065762/validate_score:v4
+    dockerPull: docker.synapse.org/syn53065762/validate_score:v5

--- a/steps/score.cwl
+++ b/steps/score.cwl
@@ -37,4 +37,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn53065762/validate_score:v4
+    dockerPull: docker.synapse.org/syn53065762/validate_score:v5

--- a/steps/unzip_submission.cwl
+++ b/steps/unzip_submission.cwl
@@ -36,8 +36,12 @@ outputs:
       outputEval: $(JSON.parse(self[0].contents)['submission_errors'])
       loadContents: true
 
-baseCommand: python3
+baseCommand: python
 arguments:
-  - valueFrom: unzip_submission.py
+  - valueFrom: MIDI_validation_script/unzip_submission.py
   - prefix: --compressed_file
     valueFrom: $(inputs.compressed_file)
+
+hints:
+  DockerRequirement:
+    dockerPull: docker.synapse.org/syn53065762/validate_score:v5


### PR DESCRIPTION
The `unzip_submission.py` file has been incorporated into the docker image that runs the midi scoring/validation scripts.

`unzip_submission.cwl`has been updated to include the docker image and allow execution of the script in the container.

The new docker image, `v5`, has been added to Synapse.