### PR TITLE
update workflow and discrepancy/validation inputs

### DIFF
--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -48,6 +48,7 @@ arguments:
   - valueFrom: /usr/local/bin/MIDI_validation_script/run_reports.py
   - prefix: --compressed_file
     valueFrom: $(inputs.compressed_file)
+  - valueFrom: $(inputs.database_created)
 
 hints:
   DockerRequirement:

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -165,15 +165,17 @@ steps:
         source: "#create_scoring_report/database_created"
     out:
       - id: discrepancy_results
+      - id: discrepancy_internal
+      - id: scoring_results
 
 
-  create_dciodvfy_report:
-    run: steps/dicovdfy.cwl
-    in:
-      - id: compressed_file
-        source: "#download_submission/filepath"
-    out:
-      - id: dciodvfy_results
+  # create_dciodvfy_report:
+  #   run: steps/dicovdfy.cwl
+  #   in:
+  #     - id: compressed_file
+  #       source: "#download_submission/filepath"
+  #   out:
+  #     - id: dciodvfy_results
 
   upload_to_synapse:
     run: steps/synapse_upload.cwl


### PR DESCRIPTION
Removed the dciodvfy portion of workflow.cwl at the Organizers' request and added additional arguments to running run_validation.py from the discrepancy.cwl