### PR TITLE
Remove dciodvfy output and duplicate synid from workflow.cwl

### DIFF
--- a/workflow.cwl
+++ b/workflow.cwl
@@ -184,16 +184,18 @@ steps:
         source: "#synapseConfig"
       - id: parent_id  # this input is needed so that Synapse knows where to upload file
         source: "#adminUploadSynId"
-      - id: dciodvfy_results
-        source: "#create_dciodvfy_report/dciodvfy_results"
+      # removed since this step is no longer happening
+      # - id: dciodvfy_results
+      #   source: "#create_dciodvfy_report/dciodvfy_results"
       - id: discrepancy_results
         source: "#create_discrepancy_report/discrepancy_results"
       - id: scoring_results
         source: "#create_scoring_report/scoring_results"
     out:
-      - id: dciodvfy_synid
+      # removed since this step is no longer happening
+      # - id: dciodvfy_synid
       - id: discrepancy_synid
-      - id: scoring_synid
+      # - id: scoring_synid
       - id: results
       
   # download_goldstandard:


### PR DESCRIPTION
workflow.cwl upload_to_synapse listed the scoring and discrepancy synIDs as output. These IDs are the same. Removed the scoring synID output. Removed the dciodvfy_synID variable since the step no longer occurs.