### PR TITLE
change the basecommand arguments to work for filepaths

### DIFF
--- a/steps/dicovdfy.cwl
+++ b/steps/dicovdfy.cwl
@@ -33,7 +33,7 @@ baseCommand: python
 arguments:
   - valueFrom: /usr/local/bin/MIDI_validation_script/run_dciodvfy.py
   - prefix: --compressed_file
-    valueFrom: $(inputs.compressed_file)
+    valueFrom: $(inputs.compressed_file.path)
 
 hints:
   DockerRequirement:

--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -47,7 +47,7 @@ baseCommand: python
 arguments:
   - valueFrom: /usr/local/bin/MIDI_validation_script/run_reports.py
   - prefix: --compressed_file
-    valueFrom: $(inputs.compressed_file)
+    valueFrom: $(inputs.compressed_file.path)
   - valueFrom: $(inputs.database_created)
 
 hints:

--- a/steps/score.cwl
+++ b/steps/score.cwl
@@ -38,7 +38,7 @@ baseCommand: python
 arguments:
   - valueFrom: /usr/local/bin/MIDI_validation_script/run_validation.py
   - prefix: --compressed_file
-    valueFrom: $(inputs.compressed_file)
+    valueFrom: $(inputs.compressed_file.path)
 
 hints:
   DockerRequirement:


### PR DESCRIPTION
Added.path to each of the steps folder .cwl files that requires the use of the compressed directory gathered from downloading the submission.