### PR TITLE
update the discrepancy cwl to match correct commands for python script

### DIFF
--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -6,49 +6,38 @@ label: Run the submission against the Organizers pipeline for Discrepancies
 
 requirements:
   - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - $(inputs.database_created)  # Ensure the database file is in the working directory
 
 inputs:
-  - id: compressed_file
+  compressed_file:
     type: File
-  - id: database_created
+    inputBinding:
+      position: 1  # Ensures this input appears directly as the first argument
+  database_created:
     type: File
 
 outputs:
-
-  - id: scoring_results
+  scoring_results:
     type: File
     outputBinding:
       glob: scoring_report_series.xlsx
 
-  - id: discrepancy_results
+  discrepancy_results:
     type: File
     outputBinding:
       glob: discrepancy_report_participant.csv
   
-  - id: discrepancy_internal
+  discrepancy_internal:
     type: File
     outputBinding:
       glob: discrepancy_report_internal.csv
-  
-
-  # - id: results
-  #   type: File
-  #   outputBinding:
-  #     glob: results.json
-
-  # - id: status
-  #   type: string
-  #   outputBinding:
-  #     glob: results.json
-  #     outputEval: $(JSON.parse(self[0].contents)['submission_status'])
-  #     loadContents: true
 
 baseCommand: python
 arguments:
-  - valueFrom: /usr/local/bin/MIDI_validation_script/run_reports.py
-  - prefix: --compressed_file
-    valueFrom: $(inputs.compressed_file.path)
-  - valueFrom: $(inputs.database_created)
+  - /usr/local/bin/MIDI_validation_script/run_reports.py
+  - $(inputs.compressed_file.path)
 
 hints:
   DockerRequirement:


### PR DESCRIPTION
discrepancy.cwl has been updated to ensure the validation_database created when score.cwl runs run_validation.py is accessible within the working directory. The base command was updated to remove the prefix previously used to align with the cli run statement for run_reports.py