### PR TITLE
Make the database in the Docker Container accessible

### DIFF
--- a/steps/score.cwl
+++ b/steps/score.cwl
@@ -6,13 +6,18 @@ label: Run the submission against the Organizers pipeline for Scoring
 
 requirements:
   - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: /MIDI_validation_script/midi_1_1_answer_data_1.db
+        entry: $(inputs.answer_database.path)  # Ensure the database file is available in the container
 
 inputs:
   compressed_file:
     type: File
     inputBinding:
       position: 1  # Ensures this input appears directly as the first argument
-
+  answer_database:
+    type: File
 outputs:
   scoring_results:
     type: File
@@ -32,4 +37,3 @@ arguments:
 hints:
   DockerRequirement:
     dockerPull: docker.synapse.org/syn53065762/validate_score:v12
-


### PR DESCRIPTION
The answer database within the docker container file structure was inaccessible so InitialWorkDirRequirement was updated to make it usable.