### PR TITLE
Change the location of Passed Database

### DIFF
--- a/steps/discrepancy.cwl
+++ b/steps/discrepancy.cwl
@@ -8,7 +8,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: InitialWorkDirRequirement
     listing:
-      - entryname: validation_results.db
+      - entryname: MIDI_validation_script/validation_results.db
         entry: $(inputs.database_created.path)
 
 inputs:


### PR DESCRIPTION
There is an error in reading the database and saying there is no folder named modules so I've changed the location of the validation_results.db to be w/in the MIDI_validation_script folder