### PR TITLE
Implement the dciovdfy portion of the Organizers workflow

### DIFF
--- a/docker/get_score.py
+++ b/docker/get_score.py
@@ -10,7 +10,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--scoring_file", type=str, required=True)
     parser.add_argument("--results_file", type=str, required=True)
-    # parser.add_argument("--output", type=str, default="output_combined.json")
+    parser.add_argument("--output", type=str, default="output_combined.json")
     return parser.parse_args()
 
 def get_score(filename):
@@ -23,7 +23,7 @@ def get_score(filename):
 
     return final_score
 
-def update_results_file(results_file, score):
+def update_results_file(results_file, score, output_file):
     """Update the output file with the new score."""
     try:
         with open(results_file, "r") as file:
@@ -42,7 +42,7 @@ def main():
     score = get_score(args.scoring_file)
     
     # Update the output file with the score
-    update_results_file(args.results_file, score)
+    update_results_file(args.results_file, score, args.output)
 
 if __name__ == "__main__":
     main()

--- a/steps/email_results.cwl
+++ b/steps/email_results.cwl
@@ -99,4 +99,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.7.2(synapseenv)
+    dockerPull: sagebionetworks/synapsepythonclient:v2.7.2

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -100,4 +100,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: sagebionetworks/synapsepythonclient:v2.7.2(synapseenv) 
+    dockerPull: sagebionetworks/synapsepythonclient:v2.7.2

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -67,7 +67,8 @@ baseCommand: ["/bin/bash", "-c"]
 arguments:
   - |
     python /usr/local/bin/MIDI_validation_script/run_validation.py $(inputs.compressed_file.path) && \
-    python /usr/local/bin/MIDI_validation_script/run_reports.py $(inputs.compressed_file.path)
+    python /usr/local/bin/MIDI_validation_script/run_reports.py $(inputs.compressed_file.path) && \
+    python /usr/local/bin/MIDI_validation_script/run_dciodvfy.py $(inputs.compressed_file.path)
 
 hints:
   DockerRequirement:


### PR DESCRIPTION
The test.cwl will attempt to run the run_dciodvfy.py portion of the organizers supplied code. No changes to outputs were added to test.cwl as the goal is to see if running it throws an error. If it doesn't the other cwl workflow steps will be updated to reflect the output.


There was also additional unneeded text tied to the docker pull commands in email_results.cwl and synapse_upload.cwl that was removed.