### PR TITLE
sync upstream with the final phase workflow updates

### DIFF
--- a/steps/email_results.cwl
+++ b/steps/email_results.cwl
@@ -52,17 +52,22 @@ requirements:
           if csv_full_id:
             del annots['scoring']
           subject = f"Submission to '{evaluation.name}' scored!"
+          # message = [
+          #  f"Hello {name},\n\n",
+          #  f"Your submission (id: {sub.id}) has been scored and below are the metric averages:\n\n",
+          #  "\n".join([i + " : " + str(annots[i]) for i in annots]),
+          #  "\n\n"
+          # ]
           message = [
             f"Hello {name},\n\n",
-            f"Your submission (id: {sub.id}) has been scored and below are the metric averages:\n\n",
-            "\n".join([i + " : " + str(annots[i]) for i in annots]),
+            f"Your submission (id: {sub.id}) has been scored, and the results will be posted here: https://www.synapse.org/Synapse:syn53065760/wiki/629528."
             "\n\n"
           ]
-          if csv_full_id:
-            message.append(f"Your scoring report is available here: https://www.synapse.org/#!Synapse:{csv_id}")
+          # if csv_full_id:
+            # message.append(f"Your scoring report is available here: https://www.synapse.org/#!Synapse:{csv_id}")
             # message.append(f"\nLegacy scores are available here: https://www.synapse.org/#!Synapse:{csv_full_id}")
-          else:
-            message.append(f"Your report is available here: https://www.synapse.org/#!Synapse:{csv_id}")
+          # else:
+            # message.append(f"Your report is available here: https://www.synapse.org/#!Synapse:{csv_id}")
           message.append("\n\nSincerely,\nChallenge Administrator")
           syn.sendMessage(
               userIds=[participantid],

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -67,6 +67,7 @@ requirements:
           # Add submitted file to synapse
           submitted_file = synapseclient.File(args.compressed_file, parent=args.parent_id)
           submitted_file = syn.store(submitted_file)
+          results['submitted_file'] = submitted_file.id
 
           with open('results.json', 'w') as out:
               json.dump(results, out)

--- a/steps/synapse_upload.cwl
+++ b/steps/synapse_upload.cwl
@@ -23,6 +23,7 @@ requirements:
           parser.add_argument("--discrepancy_file", required=True)
           parser.add_argument("--scoring_file", required=True)
           parser.add_argument("--score_value", required=True)
+          parser.add_argument("--compressed_file", required=True)
           parser.add_argument("--synapse_config", required=True)
           parser.add_argument("--parent_id", required=True)
           args = parser.parse_args()
@@ -63,6 +64,10 @@ requirements:
           score = syn.store(scoring)
           results['score'] = data
 
+          # Add submitted file to synapse
+          submitted_file = synapseclient.File(args.compressed_file, parent=args.parent_id)
+          submitted_file = syn.store(submitted_file)
+
           with open('results.json', 'w') as out:
               json.dump(results, out)
 
@@ -73,6 +78,8 @@ inputs:
     type: File
   - id: score_value
     type: File
+  - id: compressed_file
+    type: File  
   - id: parent_id
     type: string
   - id: synapse_config
@@ -93,6 +100,8 @@ arguments:
   - valueFrom: $(inputs.scoring_results.path)
   - valueFrom: --score_value
   - valueFrom: $(inputs.score_value.path)
+  - valueFrom: --compressed_file
+  - valueFrom: $(inputs.compressed_file.path)
   - valueFrom: --synapse_config
   - valueFrom: $(inputs.synapse_config.path)
   - valueFrom: --parent_id

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -73,4 +73,4 @@ arguments:
 
 hints:
   DockerRequirement:
-    dockerPull: docker.synapse.org/syn53065762/validate_score:v12
+    dockerPull: docker.synapse.org/syn53065762/create_reports:v1.0.0

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -19,12 +19,12 @@ outputs:
   pixel_results:
     type: File
     outputBinding:
-      glob: 'results/pixel_validation.xlsx'
+      glob: 'results/MIDI_1_1_Testing_Phase/pixel_validation.xlsx'
 
   database_created:
     type: File
     outputBinding:
-      glob: 'results/validation_results.db'
+      glob: 'results/MIDI_1_1_Testing_Phase/validation_results.db'
 
   results:
     type: File

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -19,12 +19,12 @@ outputs:
   pixel_results:
     type: File
     outputBinding:
-      glob: 'results/MIDI_1_1_Testing/pixel_validation.xlsx'
+      glob: 'results/pixel_validation.xlsx'
 
   database_created:
     type: File
     outputBinding:
-      glob: 'results/MIDI_1_1_Testing/validation_results.db'
+      glob: 'results/validation_results.db'
 
   results:
     type: File

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -66,6 +66,7 @@ outputs:
 baseCommand: ["/bin/bash", "-c"]
 arguments:
   - |
+    cp -r /usr/local/bin/MIDI_validation_script . && \ # copy inputs to the working dir
     python /usr/local/bin/MIDI_validation_script/run_validation.py $(inputs.compressed_file.path) && \
     python /usr/local/bin/MIDI_validation_script/run_reports.py $(inputs.compressed_file.path) # && \
     # mkdir dciodvfy && \

--- a/steps/test.cwl
+++ b/steps/test.cwl
@@ -48,17 +48,17 @@ outputs:
   scoring_results:
     type: File
     outputBinding:
-      glob: 'results/MIDI_1_1_Testing/scoring_report_series.xlsx'
+      glob: 'results/MIDI_1_1_Testing_Phase/scoring_report_series.xlsx'
 
   discrepancy_results:
     type: File
     outputBinding:
-      glob: 'results/MIDI_1_1_Testing/discrepancy_report_participant.csv'
+      glob: 'results/MIDI_1_1_Testing_Phase/discrepancy_report_participant.csv'
   
   discrepancy_internal:
     type: File
     outputBinding:
-      glob: 'results/MIDI_1_1_Testing/discrepancy_report_internal.csv'
+      glob: 'results/MIDI_1_1_Testing_Phase/discrepancy_report_internal.csv'
 
   
 

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -186,7 +186,7 @@ steps:
       - id: synapse_config   # this input is needed so that uploading to Synapse is possible
         source: "#synapseConfig"
       - id: parent_id  # this input is needed so that Synapse knows where to upload file
-        source: "#submitterUploadSynId"
+        source: "#adminUploadSynId"
     out:
       - id: results
     

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -94,7 +94,7 @@ steps:
       - id: scoring_results
       - id: discrepancy_results
       - id: discrepancy_internal
-    
+  
   notify_filepath_status:
     doc: Notify participant if submission is not acceptable.
     run: |-
@@ -181,6 +181,8 @@ steps:
         source: "#create_scoring_report/scoring_results"
       - id: score_value
         source: "#get_score/results"
+      - id: compressed_file
+        source: "#download_submission/filepath"
       - id: synapse_config   # this input is needed so that uploading to Synapse is possible
         source: "#synapseConfig"
       - id: parent_id  # this input is needed so that Synapse knows where to upload file


### PR DESCRIPTION
## Changelogs
- update testing data path
- update the scoring docker image (source codes can be found in this [private repo](https://github.com/rrchai/MIDI-B-De-identification-Docker))
- not return scores to the participants in emails
- upload the submission files to the admin log folder